### PR TITLE
Migrate to FlutterPlugin API

### DIFF
--- a/android/src/main/kotlin/finaldev/motion_sensors/MotionSensorsPlugin.kt
+++ b/android/src/main/kotlin/finaldev/motion_sensors/MotionSensorsPlugin.kt
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.PluginRegistry.Registrar
 
 // translate from https://github.com/flutter/plugins/tree/master/packages/sensors
 /** MotionSensorsPlugin */
@@ -45,14 +44,6 @@ public class MotionSensorsPlugin : FlutterPlugin, MethodChannel.MethodCallHandle
   private var orientationStreamHandler: RotationVectorStreamHandler? = null
   private var absoluteOrientationStreamHandler: RotationVectorStreamHandler? = null
   private var screenOrientationStreamHandler: ScreenOrientationStreamHandler? = null
-
-  companion object {
-    @JvmStatic
-    fun registerWith(registrar: Registrar) {
-      val plugin = MotionSensorsPlugin()
-      plugin.setupEventChannels(registrar.context(), registrar.messenger())
-    }
-  }
 
   override fun onAttachedToEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     val context = binding.applicationContext

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -16,12 +16,12 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+            />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.


### PR DESCRIPTION
This PR updates the plugin to use the new FlutterPlugin API, replacing the deprecated Registrar API, which has been completely removed in Flutter 3.28.x.

Issue:
	•	The plugin was still using the old Registrar-based initialization, which was deprecated in Flutter 1.12 (2019) and fully removed in Flutter 3.28.x.
	•	This caused an “Unresolved reference: Registrar” error when trying to build the project.

Fix:
	•	Migrated the plugin to use the FlutterPlugin API, ensuring compatibility with the latest Flutter versions.
	
For further information see [the flutter documentation](https://docs.flutter.dev/release/breaking-changes/plugin-api-migration)
